### PR TITLE
Peripherals

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -1,0 +1,26 @@
+
+pub trait CanExt {
+    fn constrain(self) -> Can;
+}
+
+impl CanExt for Can {
+    fn constrain(self) -> Can {
+        Can {}
+    }
+}
+
+pub struct Can {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/ccu40.rs
+++ b/src/ccu40.rs
@@ -1,0 +1,27 @@
+
+
+pub trait Ccu40Ext {
+    fn constrain(self) -> Ccu40;
+}
+
+impl Ccu40Ext for Ccu40 {
+    fn constrain(self) -> Ccu40 {
+        Ccu40 {}
+    }
+}
+
+pub struct Ccu40 {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/ccu80.rs
+++ b/src/ccu80.rs
@@ -1,0 +1,27 @@
+
+
+pub trait Ccu80Ext {
+    fn constrain(self) -> Ccu80;
+}
+
+impl Ccu80Ext for Ccu80 {
+    fn constrain(self) -> Ccu80 {
+        Ccu80 {}
+    }
+}
+
+pub struct Ccu80 {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -1,0 +1,27 @@
+
+
+pub trait DacExt {
+    fn constrain(self) -> Dac;
+}
+
+impl DacExt for Dac {
+    fn constrain(self) -> Dac {
+        Dac {}
+    }
+}
+
+pub struct Dac {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/dlr.rs
+++ b/src/dlr.rs
@@ -1,0 +1,27 @@
+
+
+pub trait DlrExt {
+    fn constrain(self) -> Dlr;
+}
+
+impl DlrExt for Dlr {
+    fn constrain(self) -> Dlr {
+        Dlr {}
+    }
+}
+
+pub struct Dlr {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/eru.rs
+++ b/src/eru.rs
@@ -1,0 +1,27 @@
+
+
+pub trait EruExt {
+    fn constrain(self) -> Eru;
+}
+
+impl EruExt for Eru {
+    fn constrain(self) -> Eru {
+        Eru {}
+    }
+}
+
+pub struct Eru {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/fce.rs
+++ b/src/fce.rs
@@ -1,0 +1,27 @@
+
+
+pub trait FceExt {
+    fn constrain(self) -> Fce;
+}
+
+impl FceExt for Fce {
+    fn constrain(self) -> Fce {
+        Fce {}
+    }
+}
+
+pub struct Fce {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,0 +1,27 @@
+
+
+pub trait FlashExt {
+    fn constrain(self) -> Flash;
+}
+
+impl FlashExt for Flash {
+    fn constrain(self) -> Flash {
+        Flash {}
+    }
+}
+
+pub struct Flash {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/gpdma.rs
+++ b/src/gpdma.rs
@@ -1,0 +1,27 @@
+
+
+pub trait GpdmaExt {
+    fn constrain(self) -> Gpdma;
+}
+
+impl GpdmaExt for Gpdma {
+    fn constrain(self) -> Gpdma {
+        Gpdma {}
+    }
+}
+
+pub struct Gpdma {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/hrpwm.rs
+++ b/src/hrpwm.rs
@@ -1,0 +1,27 @@
+
+
+pub trait HrpwmExt {
+    fn constrain(self) -> Hrpwm;
+}
+
+impl HrpwmExt for Hrpwm {
+    fn constrain(self) -> Hrpwm {
+        Hrpwm {}
+    }
+}
+
+pub struct Hrpwm {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/ledts.rs
+++ b/src/ledts.rs
@@ -1,0 +1,27 @@
+
+
+pub trait LedtsExt {
+    fn constrain(self) -> Ledts;
+}
+
+impl LedtsExt for Ledts {
+    fn constrain(self) -> Ledts {
+        Ledts {}
+    }
+}
+
+pub struct Ledts {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,51 @@ pub use xmc4800;
 pub use xmc4800 as device;
 
 #[cfg(feature = "device-selected")]
+pub mod can;
+#[cfg(feature = "device-selected")]
+pub mod ccu40;
+#[cfg(feature = "device-selected")]
+pub mod ccu80;
+#[cfg(feature = "device-selected")]
+pub mod dac;
+#[cfg(feature = "device-selected")]
+pub mod dlr;
+#[cfg(feature = "device-selected")]
+pub mod eru;
+#[cfg(feature = "device-selected")]
+pub mod fce;
+#[cfg(feature = "device-selected")]
+pub mod flash;
+#[cfg(feature = "device-selected")]
+pub mod gpdma;
+#[cfg(feature = "device-selected")]
+pub mod hrpwm;
+#[cfg(feature = "device-selected")]
+pub mod ledts;
+#[cfg(feature = "device-selected")]
+pub mod pba;
+#[cfg(feature = "device-selected")]
+pub mod pmu;
+#[cfg(feature = "device-selected")]
+pub mod port;
+#[cfg(feature = "device-selected")]
+pub mod posif;
+#[cfg(feature = "device-selected")]
+pub mod ppb;
+#[cfg(feature = "device-selected")]
+pub mod pref;
+#[cfg(feature = "device-selected")]
 pub mod rtc;
 #[cfg(feature = "device-selected")]
 pub mod scu;
+#[cfg(feature = "device-selected")]
+pub mod usb;
+#[cfg(feature = "device-selected")]
+pub mod usic;
+#[cfg(feature = "device-selected")]
+pub mod vadc;
+#[cfg(feature = "device-selected")]
+pub mod wdt;
 
 
 #[cfg(test)]

--- a/src/pba.rs
+++ b/src/pba.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PbaExt {
+    fn constrain(self) -> Pba;
+}
+
+impl PbaExt for Pba {
+    fn constrain(self) -> Pba {
+        Pba {}
+    }
+}
+
+pub struct Pba {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PmuExt {
+    fn constrain(self) -> Pmu;
+}
+
+impl PmuExt for Pmu {
+    fn constrain(self) -> Pmu {
+        Pmu {}
+    }
+}
+
+pub struct Pmu {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PortExt {
+    fn constrain(self) -> Port;
+}
+
+impl PortExt for Port {
+    fn constrain(self) -> Port {
+        Port {}
+    }
+}
+
+pub struct Port {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/posif.rs
+++ b/src/posif.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PosifExt {
+    fn constrain(self) -> Posif;
+}
+
+impl PosifExt for Posif {
+    fn constrain(self) -> Posif {
+        Posif {}
+    }
+}
+
+pub struct Posif {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/ppb.rs
+++ b/src/ppb.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PpbExt {
+    fn constrain(self) -> Ppb;
+}
+
+impl PpbExt for Ppb {
+    fn constrain(self) -> Ppb {
+        Ppb {}
+    }
+}
+
+pub struct Ppb {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/pref.rs
+++ b/src/pref.rs
@@ -1,0 +1,27 @@
+
+
+pub trait PrefExt {
+    fn constrain(self) -> Pref;
+}
+
+impl PrefExt for Pref {
+    fn constrain(self) -> Pref {
+        Pref {}
+    }
+}
+
+pub struct Pref {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,0 +1,27 @@
+
+
+pub trait UsbExt {
+    fn constrain(self) -> Usb;
+}
+
+impl UsbExt for Usb {
+    fn constrain(self) -> Usb {
+        Usb {}
+    }
+}
+
+pub struct Usb {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/usic.rs
+++ b/src/usic.rs
@@ -1,0 +1,27 @@
+
+
+pub trait UsicExt {
+    fn constrain(self) -> Usic;
+}
+
+impl UsicExt for Usic {
+    fn constrain(self) -> Usic {
+        Usic {}
+    }
+}
+
+pub struct Usic {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/vadc.rs
+++ b/src/vadc.rs
@@ -1,0 +1,27 @@
+
+
+pub trait VadcExt {
+    fn constrain(self) -> Vadc;
+}
+
+impl VadcExt for Vadc {
+    fn constrain(self) -> Vadc {
+        Vadc {}
+    }
+}
+
+pub struct Vadc {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}

--- a/src/wdt.rs
+++ b/src/wdt.rs
@@ -1,0 +1,27 @@
+
+
+pub trait WdtExt {
+    fn constrain(self) -> Wdt;
+}
+
+impl WdtExt for Wdt {
+    fn constrain(self) -> Wdt {
+        Wdt {}
+    }
+}
+
+pub struct Wdt {}
+
+// IMPLEMENT PERIPHERAL AFTER THIS LINE
+
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn nothing() {
+        // Do nothing test
+    }
+}


### PR DESCRIPTION
Adding initial base code for the high level peripherals.  This does not implement past definitions and does not create defines for duplicate peripheral instances.