### PR TITLE
Test Super use Removal

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -14,8 +14,6 @@ pub struct Can {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/ccu40.rs
+++ b/src/ccu40.rs
@@ -14,8 +14,6 @@ pub struct Ccu40 {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/ccu80.rs
+++ b/src/ccu80.rs
@@ -14,8 +14,6 @@ pub struct Ccu80 {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -14,8 +14,6 @@ pub struct Dac {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/dlr.rs
+++ b/src/dlr.rs
@@ -14,8 +14,6 @@ pub struct Dlr {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/eru.rs
+++ b/src/eru.rs
@@ -14,8 +14,6 @@ pub struct Eru {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/fce.rs
+++ b/src/fce.rs
@@ -14,8 +14,6 @@ pub struct Fce {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -14,8 +14,6 @@ pub struct Flash {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/gpdma.rs
+++ b/src/gpdma.rs
@@ -14,8 +14,6 @@ pub struct Gpdma {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/hrpwm.rs
+++ b/src/hrpwm.rs
@@ -14,8 +14,6 @@ pub struct Hrpwm {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/ledts.rs
+++ b/src/ledts.rs
@@ -14,8 +14,6 @@ pub struct Ledts {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,6 @@ pub mod wdt;
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/pba.rs
+++ b/src/pba.rs
@@ -14,8 +14,6 @@ pub struct Pba {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -14,8 +14,6 @@ pub struct Pmu {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/port.rs
+++ b/src/port.rs
@@ -14,8 +14,6 @@ pub struct Port {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/posif.rs
+++ b/src/posif.rs
@@ -14,8 +14,6 @@ pub struct Posif {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/ppb.rs
+++ b/src/ppb.rs
@@ -14,8 +14,6 @@ pub struct Ppb {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/pref.rs
+++ b/src/pref.rs
@@ -14,8 +14,6 @@ pub struct Pref {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -14,8 +14,6 @@ pub struct Usb {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/usic.rs
+++ b/src/usic.rs
@@ -14,8 +14,6 @@ pub struct Usic {}
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/vadc.rs
+++ b/src/vadc.rs
@@ -336,8 +336,6 @@ impl Vadc {
 
 #[cfg(test)]
 mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
 
     #[test]
     fn nothing() {

--- a/src/wdt.rs
+++ b/src/wdt.rs
@@ -124,7 +124,6 @@ impl Wdt {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn nothing() {


### PR DESCRIPTION
Removing uses of super from unit tests as it caused warnings and is not necessary to have to get coverage information.