### PR TITLE
Downgrade as-slice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ cortex-m-rtfm = "0.5.0"
 cortex-m-semihosting = "0.3.5"
 heapless = "0.5.1"
 libm = "0.2.1"
-as-slice = "0.2.0"
+as-slice = "0.1.2"
 
 [dev-dependencies.byteorder]
 default-features = false


### PR DESCRIPTION
0.2.0 was yanked so I am downstepping this to the latest 0.1.2

Fixes #75